### PR TITLE
Snhut 1562 - Filter User Table to Active Users Only by Default

### DIFF
--- a/apps/toboggan-app/src/app/shared/services/table-data/table-data.service.ts
+++ b/apps/toboggan-app/src/app/shared/services/table-data/table-data.service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { Injectable } from '@angular/core';
 import {
@@ -7,17 +8,18 @@ import { Observable, Subscription } from 'rxjs';
 import { TableSortingService } from '../table-sorting/table-sorting.service';
 
 export interface ITableRowFilterFunc{
-  (tr:TableRow, columnMetadata:TableColumnDisplayMetadatum[], searchString:string): boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (tr:TableRow, columnMetadata?:TableColumnDisplayMetadatum[], searchVal?:unknown): boolean;
 }
 
 export interface ICelldataFormatterFunc{
-  (dataArray:any): TableRow[];
+  (dataArray:unknown): TableRow[];
 }
 
 export interface ITableDataGeneratorFactoryOutput{
   dataGenerator: SingleHeaderRowTableDataGenerator,
   tableRows?: TableRow[],
-  rawData?: any
+  rawData?: unknown
 }
 
 @Injectable({
@@ -58,8 +60,8 @@ export class TableDataService {
           (
             dataGenerator: TableDataGenerator,
             columnDisplayMetadata: TableColumnDisplayMetadatum[],
-            searchString:string = dataGenerator.searchString,
-            pageSize:number = rowsPerPage,
+            _searchString:string = dataGenerator.searchString,
+            _pageSize:number = rowsPerPage,
             currentPage:number = currentPageNumer
           )=>{
             rowsObservableSubscription = rowsObservable

--- a/apps/toboggan-app/src/app/user/components/user-table/data/user-table-header.ts
+++ b/apps/toboggan-app/src/app/user/components/user-table/data/user-table-header.ts
@@ -10,6 +10,7 @@ export const userTableHeader = [
     dataKey: 'first',
     parents: '',
     alignment: TableColumnAlignmentEnum.Left,
+    sort: TableColumnSortStateEnum.Ascending,
     searchableField: true
   },
   {
@@ -32,6 +33,6 @@ export const userTableHeader = [
     sort: TableColumnSortStateEnum.None,
     alignment: TableColumnAlignmentEnum.Left,
     dataType: TableColumnDataTypeEnum.Tag,
-    selectedFilters: { Active: false, Inactive: false },
+    selectedFilters: { Active: true, Inactive: false },
   },
 ];


### PR DESCRIPTION
- Table should load with active users by default - meaning the status filter should come with "Active" pre-selected by default. (It's my interpretation of the requirement)
- The filter should work alongside table searching
- If both _Active_ and _Inactive_ states are chosen in the filter, the table will show all of the rows, otherwise it will filter accordingly

#### Small Demo:

https://user-images.githubusercontent.com/107949139/186020861-61133385-1e5c-4153-aa69-bfaf494537c5.mp4


