### PR TITLE
SNHUT-582 User Management Password Reset Success or Error State Front-end Pt.1

### DIFF
--- a/apps/toboggan-api/src/controllers/users/users.controller.ts
+++ b/apps/toboggan-api/src/controllers/users/users.controller.ts
@@ -3,11 +3,13 @@ import {
   Controller,
   Delete,
   Get,
+  HttpException,
+  HttpStatus,
   Param,
   Patch,
   Post,
   Put,
-  Query,
+  Query
 } from '@nestjs/common';
 import { IUser } from '@toboggan-ws/toboggan-common';
 import { UsersService } from '../../providers/users/users.service';
@@ -37,10 +39,24 @@ export class UsersController {
     return this.usersService.updateUser(id, user);
   }
 
+  @Put('/:id/password')
+  resetPasswordOfUser(@Param('id') id, @Body() operationBody: {
+    type: string
+  } ) {
+    switch(operationBody.type){
+      case ('reset'):
+        this.usersService.resetPasswordOfUser(id);
+        break;
+      default:
+        throw new HttpException({status: HttpStatus.BAD_REQUEST, error:`Invalid request-body!`}, HttpStatus.BAD_REQUEST);
+    }
+  }
+
   @Patch('/:id')
   patchUser(@Param('id') id, @Body() user: IUser) {
     return this.usersService.patchUser(id, user);
   }
+
 
   @Delete('/:id')
   deleteUser(@Param('id') id) {

--- a/apps/toboggan-api/src/providers/users/users.service.ts
+++ b/apps/toboggan-api/src/providers/users/users.service.ts
@@ -78,6 +78,19 @@ export class UsersService {
     });
   }
 
+  resetPasswordOfUser(id: string) {
+    // forward the pwd-reset request to the back-end
+    // this does not do anything at the moment
+    this.users = this.users.map((user) => {
+      if (user.id === id) {
+        return {
+          ...user
+        };
+      }
+      return user;
+    });
+  }
+
   deleteUser(id: string) {
     this.users = this.users.filter((user) => {
       return user.id !== id;

--- a/apps/toboggan-app/src/app/group/components/group-list/group-list.component.ts
+++ b/apps/toboggan-app/src/app/group/components/group-list/group-list.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import {
   TableColumnDisplayMetadatum,
   TableDataGenerator,
-  TableRow,
+  TableRow
 } from '@snhuproduct/toboggan-ui-components-library';
 import { IRowActionEvent } from '@snhuproduct/toboggan-ui-components-library/lib/table/row-action-event.interface';
 import { IGroup } from '@toboggan-ws/toboggan-common';
@@ -13,7 +13,7 @@ import { IBannerButton } from '../../../shared/services/banner/banner.types';
 import { ModalAlertService } from '../../../shared/services/modal-alert/modal-alert.service';
 import {
   ITableDataGeneratorFactoryOutput,
-  TableDataService,
+  TableDataService
 } from '../../../shared/services/table-data/table-data.service';
 import { GroupService } from '../../services/group.service';
 import { groupTableHeader, RowActions } from './group-table.type';

--- a/apps/toboggan-app/src/app/shared/services/user/user.service.ts
+++ b/apps/toboggan-app/src/app/shared/services/user/user.service.ts
@@ -31,9 +31,7 @@ export class UserService {
   }
 
   async resetPassword(userId: string): Promise<unknown> {
-    // TODO: endpoint for reset password
-    // back-end doesn't have an endpoint to reset password yet; doing dummy GET
-    return firstValueFrom(this.http.get(`/api/users?id=${userId}`));
+    return firstValueFrom(this.http.put(`/api/users/${userId}/password`, {type:'reset'}));
   }
 
   async updateUser(updatedUser: IUpdatedUser, userId: string): Promise<void> {

--- a/apps/toboggan-app/src/app/shared/services/user/user.service.ts
+++ b/apps/toboggan-app/src/app/shared/services/user/user.service.ts
@@ -23,17 +23,21 @@ export class UserService {
 
   fetchPaginatedUsers(currentPage: number, resultsPerPage: number = 10) {
     return this.http.get<IUser[]>(
-      `/api/users?currentPage=${currentPage}&resultsPerPage=${resultsPerPage}`
-    );
+      `/api/users?currentPage=${currentPage}&resultsPerPage=${resultsPerPage}`);
   }
 
   async createUser(user: INewUser): Promise<unknown> {
     return firstValueFrom(this.http.post('/api/users', user));
   }
 
+  async resetPassword(userId: string): Promise<unknown> {
+    // TODO: endpoint for reset password
+    // back-end doesn't have an endpoint to reset password yet; doing dummy GET
+    return firstValueFrom(this.http.get(`/api/users?id=${userId}`));
+  }
+
   async updateUser(updatedUser: IUpdatedUser, userId: string): Promise<void> {
     await firstValueFrom(this.http.put(`/api/users/${userId}`, updatedUser));
-
     this.fetchUsers();
   }
 }

--- a/apps/toboggan-app/src/app/user/components/user-table/user-table.component.spec.ts
+++ b/apps/toboggan-app/src/app/user/components/user-table/user-table.component.spec.ts
@@ -60,7 +60,7 @@ describe('UserTableComponent', () => {
 
     expect(fetchUsers).toHaveBeenCalled();
 
-    expect(component.dynamicRowData).toHaveLength(mockUsers.length);
+    expect(component.getAllRows()).toHaveLength(mockUsers.length);
   });
 
   it('reset password should bring the confirmation modal', () => {

--- a/apps/toboggan-app/src/app/user/components/user-table/user-table.component.ts
+++ b/apps/toboggan-app/src/app/user/components/user-table/user-table.component.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import {
-  JSONObject, SingleHeaderRowTableDataGenerator, TableDataGenerator,
+  JSONObject, SingleHeaderRowTableDataGenerator, TableColumnDisplayMetadatum, TableDataGenerator,
   TableRow
 } from '@snhuproduct/toboggan-ui-components-library';
 import { IRowActionEvent } from '@snhuproduct/toboggan-ui-components-library/lib/table/row-action-event.interface';
@@ -61,9 +61,14 @@ export class UserTableComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    //the table should load with only active users visible. Filter is set to "Active" by default
-    //hence the status filter is passed on-init
-    this.refreshTableData([this.filterFuncs['status']]);
+    //the table should load with only active users visible (check userTableHeader). Filter is set to "Active" by default
+    //hence the status filter is applied on-init
+    userTableHeader.map((aColMetadatum:TableColumnDisplayMetadatum)=>{
+      if(aColMetadatum.filters){
+        this.filters.set(aColMetadatum.dataKey, aColMetadatum.selectedFilters)
+      }
+    })
+    this.applyActiveFilters();
   }
 
   ngOnDestroy(): void {
@@ -138,8 +143,8 @@ export class UserTableComponent implements OnInit, OnDestroy {
     };
     switch (action) {
       case RowActions.Activate:
-          this.activateUser(userId, userPayload);
-          break;
+        this.activateUser(userId, userPayload);
+        break;
       case RowActions.Deactivate:
         this.deactivateUser(userId, userPayload);
         break;
@@ -259,6 +264,13 @@ export class UserTableComponent implements OnInit, OnDestroy {
           onClick: async () => {
             try {
               this.modalAlertService.hideModalAlert();
+              await this.userService.resetPassword(id);
+              this.showNotification(
+                'success',
+                ``, //passive voice is hard; like so many things in life, sometimes, the simplest solution is the best (:
+                `Reset password email has been sent to <b>[${firstName} ${lastName}]</b>`,
+                true
+              );
               /* Handle reset password */
             } catch (error) {
               console.error(error);

--- a/apps/toboggan-app/src/app/user/components/user-table/user-table.component.ts
+++ b/apps/toboggan-app/src/app/user/components/user-table/user-table.component.ts
@@ -34,10 +34,13 @@ export class UserTableComponent implements OnInit, OnDestroy {
   private resultsPerPage = 10;
   itemName = "Users";
   dataGenerator: SingleHeaderRowTableDataGenerator = {} as TableDataGenerator;
-  dynamicRowData: TableRow[] = {} as ITableRow[];
-  users = {} as IUser[];
   private dataGeneratorFactoryOutputObserver: Observable<ITableDataGeneratorFactoryOutput> = {} as Observable<ITableDataGeneratorFactoryOutput>;
   private datageneratorSubscription: Subscription = {} as Subscription;
+  private dataGenFactoryOutput:ITableDataGeneratorFactoryOutput = {
+    dataGenerator: this.dataGenerator,
+    tableRows: [],
+    rawData: []
+  };
   private filters: Map<string, Record<string, boolean>> = new Map();
   private filterFuncs: { [key:string]: ITableRowFilterFunc } =
     {
@@ -89,12 +92,19 @@ export class UserTableComponent implements OnInit, OnDestroy {
     this.datageneratorSubscription =
       this.dataGeneratorFactoryOutputObserver.subscribe(
         (dataGeneratorFactoryOutput) => {
-          this.dataGenerator = dataGeneratorFactoryOutput.dataGenerator;
-          this.dynamicRowData = dataGeneratorFactoryOutput.tableRows as TableRow[];
-          this.users = dataGeneratorFactoryOutput.rawData as IUser[];
+          this.dataGenFactoryOutput = dataGeneratorFactoryOutput;
+          this.dataGenerator = this.dataGenFactoryOutput.dataGenerator;
           this.dataGenerator.searchString = prevSearchString;
         }
       );
+  }
+
+  getAllRows():TableRow[]{
+    return this.dataGenFactoryOutput.tableRows as TableRow[];
+  }
+
+  getAllUsers():IUser[]{
+    return this.dataGenFactoryOutput.rawData as IUser[];
   }
 
   getActionMenuItems(rowData: TableRow) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5425,11 +5425,6 @@
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
-"fsevents@^2.3.2", "fsevents@~2.3.2":
-  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  "version" "2.3.2"
-
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
   "resolved" "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"


### PR DESCRIPTION
- Addresses [SNHUT-582](https://collectiveshift.atlassian.net/browse/SNHUT-582)*
- Created a dummy endpoint to call for reset password since there is none at the moment
- Enabled banner invocation after successful/failed call to the password reset API

---
### Notes
#### [Requirement figma](https://www.figma.com/file/8HpwJ5lXT4sxAX8gqMLOHY/2022-Q2---Ready-for-Dev?node-id=50%3A13848)
<ul>
<li> Most of the heavy lifting for this item was done by Dmitriy in  <a href="https://github.com/snhuproduct/toboggan-ws/pull/37">PR 37</a> / <a href="https://collectiveshift.atlassian.net/browse/SNHUT-1237">SNHUT-1237</a> </li>
<br/>
<li> The biggest challenge was to show messages in passive voice. Our modal services assume that we'd always have <b>bold</b> text first, normal text last, which is not true in this case </li>

Eg: regular modal message:

![Screen Shot 2022-08-24 at 5 02 49 PM](https://user-images.githubusercontent.com/107949139/186527545-4c20a5f8-00e6-4cae-8c23-4a6738122595.png)


Password reset modal message:
![Screen Shot 2022-08-24 at 5 03 02 PM](https://user-images.githubusercontent.com/107949139/186526272-6b8b89d7-ac1e-4895-b8be-4cb53fc77308.png)

Oddly enough, plain HTML bold tag (`<b></b>`) worked 😃. To think of all the crazy refactoring I had considered all the way down to toboggan-ui-component to reverse the order of  bolding `heading` and `message`; fewf!

```TypeScript
this.showNotification(
      'success', // type
      ``,             //heading
      `Reset password email has been sent to <b>[${firstName} ${lastName}]</b>`,  //message
      true //autodismiss
    );
```

</ul>
