### PR TITLE
SNHUT-1576 user management initiate user password reset backend

### DIFF
--- a/apps/toboggan-api/src/controllers/users/users.controller.ts
+++ b/apps/toboggan-api/src/controllers/users/users.controller.ts
@@ -3,11 +3,13 @@ import {
   Controller,
   Delete,
   Get,
+  HttpException,
+  HttpStatus,
   Param,
   Patch,
   Post,
   Put,
-  Query,
+  Query
 } from '@nestjs/common';
 import { IUser } from '@toboggan-ws/toboggan-common';
 import { UsersService } from '../../providers/users/users.service';
@@ -37,10 +39,24 @@ export class UsersController {
     return this.usersService.updateUser(id, user);
   }
 
+  @Put('/:id/password')
+  resetPasswordOfUser(@Param('id') id, @Body() operationBody: {
+    type: string
+  } ) {
+    switch(operationBody.type){
+      case ('reset'):
+        this.usersService.resetPasswordOfUser(id);
+        break;
+      default:
+        throw new HttpException({status: HttpStatus.BAD_REQUEST, error:`Invalid request-body!`}, HttpStatus.BAD_REQUEST);
+    }
+  }
+
   @Patch('/:id')
   patchUser(@Param('id') id, @Body() user: IUser) {
     return this.usersService.patchUser(id, user);
   }
+
 
   @Delete('/:id')
   deleteUser(@Param('id') id) {

--- a/apps/toboggan-api/src/providers/users/users.service.ts
+++ b/apps/toboggan-api/src/providers/users/users.service.ts
@@ -78,6 +78,19 @@ export class UsersService {
     });
   }
 
+  resetPasswordOfUser(id: string) {
+    // forward the pwd-reset request to the back-end
+    // this does not do anything at the moment
+    this.users = this.users.map((user) => {
+      if (user.id === id) {
+        return {
+          ...user
+        };
+      }
+      return user;
+    });
+  }
+
   deleteUser(id: string) {
     this.users = this.users.filter((user) => {
       return user.id !== id;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5415,11 +5415,6 @@
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
-"fsevents@^2.3.2", "fsevents@~2.3.2":
-  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  "version" "2.3.2"
-
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
   "resolved" "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"


### PR DESCRIPTION
- Back-end part of [SNHUT-582](https://collectiveshift.atlassian.net/browse/SNHUT-1576)
   - Implements a dummy `PUT` endpoint for password reset. If successful, this does nothing. If failed, gives HTTP 400.
   - cURL format for successful request:
   <br/>

   ```bash
   curl \
    --location \
    --request PUT 'http://localhost:3333/api/users/$USER_ID/password' \
    --header 'Content-Type: application/json' \
    --data-raw '{
       "type":"reset"
    }'
   ```
- Related/dependent PR: https://github.com/snhuproduct/toboggan-ws/pull/45
- Related/dependent Jira item: [SNHUT-582](https://collectiveshift.atlassian.net/browse/SNHUT-582)