### PR TITLE
Reload on User Creation When Filter Set to Inactive

### DIFF
--- a/apps/toboggan-app/src/app/group/components/create-group/create-group.component.ts
+++ b/apps/toboggan-app/src/app/group/components/create-group/create-group.component.ts
@@ -4,7 +4,7 @@ import {
   EventEmitter,
   OnInit,
   Output,
-  ViewChild,
+  ViewChild
 } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { IGroup, INewGroup } from '@toboggan-ws/toboggan-common';
@@ -94,7 +94,6 @@ export class CreateGroupComponent implements OnInit, AfterViewInit {
       this.groupService.createGroup(group).subscribe({
         next: (response) => {
           // handle success
-          console.log(response);
           this.groupCreateAction.emit({
             group: response as IGroup,
             addUser: this.createGroupForm.value?.addUser,

--- a/apps/toboggan-app/src/app/shared/services/table-data/table-data.service.ts
+++ b/apps/toboggan-app/src/app/shared/services/table-data/table-data.service.ts
@@ -8,7 +8,6 @@ import { Observable, Subscription } from 'rxjs';
 import { TableSortingService } from '../table-sorting/table-sorting.service';
 
 export interface ITableRowFilterFunc{
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (tr:TableRow, columnMetadata?:TableColumnDisplayMetadatum[], searchVal?:unknown): boolean;
 }
 

--- a/apps/toboggan-app/src/app/user/components/create-user/create-user.component.ts
+++ b/apps/toboggan-app/src/app/user/components/create-user/create-user.component.ts
@@ -57,6 +57,7 @@ export class CreateUserComponent {
               this.bannerService.hideBanner(bannerId),
           },
         });
+        this.userService.publishUserEditComplete(userObj);
         return true;
       } catch (error) {
         this.modalHandle?.alertBanners.push({

--- a/apps/toboggan-app/src/app/user/components/user-table/user-table.component.ts
+++ b/apps/toboggan-app/src/app/user/components/user-table/user-table.component.ts
@@ -150,7 +150,6 @@ export class UserTableComponent implements OnInit, OnDestroy {
           throw new Error('Could not find user with id: ' + userId);
         }
         this.userService.setEditingUser(user);
-        console.log(`%c ${JSON.stringify(event)}`,'color:pink');
         break;
       case RowActions.Cancel:
         // just close the menu!


### PR DESCRIPTION
- HoFix for a corner case on user table - reload inactive users when filter is set to inactive and a new user is created
- Removed some comments, rogue `console.log`s
- Sequence to reproduce in main branch:
   - Set filter to <i>inactive user</i>s
   - Create a new user
   - Table does not auto reload to show new user

---
Post-fix demo:
   

https://user-images.githubusercontent.com/107949139/187322966-e482aa08-cb21-4fe0-b121-9fe0d247c9c4.mp4

