### PR TITLE
updated error messages for create group and edit group

### DIFF
--- a/apps/toboggan-app/src/app/group/components/create-group/create-group.component.html
+++ b/apps/toboggan-app/src/app/group/components/create-group/create-group.component.html
@@ -18,7 +18,7 @@
       label="User group name"
       [withIcon]="false"
       [error]="hasError('name')"
-      [errorMessage]="getErrorMessage('name', 'User group name')"
+      [errorMessage]="getErrorMessage('name')"
     >
       <input
         aria-label="input"
@@ -32,7 +32,7 @@
       size="default"
       label="User group description"
       [error]="hasError('description')"
-      [errorMessage]="getErrorMessage('description', 'User group description')"
+      [errorMessage]="getErrorMessage('description')"
     >
       <textarea
         aria-label="input"

--- a/apps/toboggan-app/src/app/group/components/create-group/create-group.component.spec.ts
+++ b/apps/toboggan-app/src/app/group/components/create-group/create-group.component.spec.ts
@@ -53,7 +53,7 @@ describe('CreateGroupComponent', () => {
       description: 'description',
       addUser: false,
     });
-    component.getErrorMessage('name', 'name');
+    component.getErrorMessage('name');
     expect(component.createGroupForm.valid).toBeFalsy();
   });
 
@@ -64,7 +64,7 @@ describe('CreateGroupComponent', () => {
       description: 'description',
       addUser: false,
     });
-    component.getErrorMessage('name', 'name');
+    component.getErrorMessage('name');
     expect(component.createGroupForm.valid).toBeFalsy();
   });
 });

--- a/apps/toboggan-app/src/app/group/components/create-group/create-group.component.ts
+++ b/apps/toboggan-app/src/app/group/components/create-group/create-group.component.ts
@@ -4,7 +4,7 @@ import {
   EventEmitter,
   OnInit,
   Output,
-  ViewChild
+  ViewChild,
 } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { IGroup, INewGroup } from '@toboggan-ws/toboggan-common';
@@ -38,7 +38,7 @@ export class CreateGroupComponent implements OnInit, AfterViewInit {
       description: new FormControl('', [
         Validators.required,
         Validators.maxLength(300),
-        this.specialCharactersValidation
+        this.specialCharactersValidation,
       ]),
       addUser: new FormControl(false),
     });
@@ -48,17 +48,17 @@ export class CreateGroupComponent implements OnInit, AfterViewInit {
     this.createGroupModal.open();
   }
 
-  getErrorMessage(controlName: string, friendlyName: string) {
+  getErrorMessage(controlName: string) {
     const control = this.createGroupForm.get(controlName);
     if (control)
       if (control.hasError('required')) {
-        return `${friendlyName} ${FormError.isRequired}`;
+        return `${FormError.empty}`;
       } else if (control.hasError('specialCharacters')) {
         return `${FormError.characters} ! @ # $`;
       } else if (control.hasError('pattern')) {
         return `${FormError.lettersAndNumbers}`;
       } else if (control.hasError('maxlength')) {
-        return `${FormError.maxLength}`;
+        return 'Shorten the description';
       }
     return '';
   }

--- a/apps/toboggan-app/src/app/group/components/edit-group/edit-group.component.html
+++ b/apps/toboggan-app/src/app/group/components/edit-group/edit-group.component.html
@@ -1,52 +1,66 @@
 <div *ngIf="mode === 'edit'">
-    <p>Update the user group’s name or description here.</p>
-    <form [formGroup]="editGroupForm">
-        <gp-input size="default" label="Group name" [withIcon]="false" [error]="hasError('name')"
-            [errorMessage]="getErrorMessage('name','Group name')">
-            <input aria-label="input" placeholder="placeholder" type="text" formControlName="name" />
-        </gp-input><br />
+  <p>Update the user group’s name or description here.</p>
+  <form [formGroup]="editGroupForm">
+    <gp-input
+      size="default"
+      label="Group name"
+      [withIcon]="false"
+      [error]="hasError('name')"
+      [errorMessage]="getErrorMessage('name')"
+    >
+      <input
+        aria-label="input"
+        placeholder="placeholder"
+        type="text"
+        formControlName="name"
+      /> </gp-input
+    ><br />
 
-        <gp-text-area size="default" label="Group description" [error]="hasError('description')"
-            [errorMessage]="getErrorMessage('description','Group description')">
-            <textarea aria-label="input"
-                placeholder="You might explain what makes this group unique, or why you're creating it"
-                formControlName="description"></textarea>
-        </gp-text-area>
-    </form>
+    <gp-text-area
+      size="default"
+      label="Group description"
+      [error]="hasError('description')"
+      [errorMessage]="getErrorMessage('description')"
+    >
+      <textarea
+        aria-label="input"
+        placeholder="You might explain what makes this group unique, or why you're creating it"
+        formControlName="description"
+      ></textarea>
+    </gp-text-area>
+  </form>
 </div>
 
 <div *ngIf="mode === 'review'" class="review-grid">
-    <div class="row review-header py-2">
-        <div class="col">
-        </div>
-        <div class="col">
-            <b>Original</b>
-        </div>
-        <div class="col">
-            <b>New</b>
-        </div>
+  <div class="row review-header py-2">
+    <div class="col"></div>
+    <div class="col">
+      <b>Original</b>
     </div>
-    <div class="row py-4">
-        <div class="col">
-            <b>User group name</b>
-        </div>
-        <div class="col">
-            {{oldGroup.name}}
-        </div>
-        <div class="col">
-            {{group.name}}
-        </div>
+    <div class="col">
+      <b>New</b>
     </div>
-    <div class="row">
-        <div class="col">
-            <b>User group description</b>
-        </div>
-        <div class="col">
-            {{oldGroup.description}}
-        </div>
-        <div class="col">
-            {{group.description}}
-        </div>
+  </div>
+  <div class="row py-4">
+    <div class="col">
+      <b>User group name</b>
     </div>
-
+    <div class="col">
+      {{ oldGroup.name }}
+    </div>
+    <div class="col">
+      {{ group.name }}
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
+      <b>User group description</b>
+    </div>
+    <div class="col">
+      {{ oldGroup.description }}
+    </div>
+    <div class="col">
+      {{ group.description }}
+    </div>
+  </div>
 </div>

--- a/apps/toboggan-app/src/app/group/components/edit-group/edit-group.component.spec.ts
+++ b/apps/toboggan-app/src/app/group/components/edit-group/edit-group.component.spec.ts
@@ -63,8 +63,8 @@ describe('EditGroupComponent', () => {
       description: 'description@',
     });
     component.hasError('name');
-    component.getErrorMessage('name', 'name');
-    component.getErrorMessage('description', 'description');
+    component.getErrorMessage('name');
+    component.getErrorMessage('description');
     expect(component.editGroupForm.valid).toBeFalsy();
   });
 
@@ -75,8 +75,8 @@ describe('EditGroupComponent', () => {
       description:
         'description description description description description description description description description description description description description description description description description description description description description description description description description description description description description description description description description description description description description description description description description description',
     });
-    component.getErrorMessage('name', 'name');
-    component.getErrorMessage('description', 'description');
+    component.getErrorMessage('name');
+    component.getErrorMessage('description');
     expect(component.editGroupForm.valid).toBeFalsy();
   });
 

--- a/apps/toboggan-app/src/app/group/components/edit-group/edit-group.component.ts
+++ b/apps/toboggan-app/src/app/group/components/edit-group/edit-group.component.ts
@@ -15,7 +15,10 @@ export class EditGroupComponent implements OnInit {
   @Input() mode = 'edit';
   @Input() group!: IGroup;
   @Input() oldGroup!: IGroup;
-  constructor(private groupService: GroupService ,private bannerService: BannerService) { }
+  constructor(
+    private groupService: GroupService,
+    private bannerService: BannerService
+  ) {}
 
   ngOnInit(): void {
     this.editGroupForm = new FormGroup({
@@ -26,22 +29,22 @@ export class EditGroupComponent implements OnInit {
       description: new FormControl(this.group.description, [
         Validators.required,
         Validators.maxLength(300),
-        this.specialCharactersValidation
-      ])
+        this.specialCharactersValidation,
+      ]),
     });
   }
 
-  getErrorMessage(controlName: string, friendlyName: string) {
+  getErrorMessage(controlName: string) {
     const control = this.editGroupForm.get(controlName);
     if (control)
       if (control.hasError('required')) {
-        return `${friendlyName} ${FormError.isRequired}`;
+        return `${FormError.empty}`;
       } else if (control.hasError('specialCharacters')) {
         return `${FormError.characters} ! @ # $`;
       } else if (control.hasError('pattern')) {
         return `${FormError.lettersAndNumbers}`;
       } else if (control.hasError('maxlength')) {
-        return `${FormError.maxLength}`;
+        return 'Shorten the description';
       }
     return '';
   }
@@ -109,7 +112,8 @@ export class EditGroupComponent implements OnInit {
           message: `<b>Edit group details</b> couldn't be completed.`,
           button: {
             label: 'Dismiss',
-            action: (bannerId: number) => this.bannerService.hideBanner(bannerId),
+            action: (bannerId: number) =>
+              this.bannerService.hideBanner(bannerId),
           },
           autoDismiss: true,
         });
@@ -117,5 +121,4 @@ export class EditGroupComponent implements OnInit {
       },
     });
   }
-
 }


### PR DESCRIPTION
### Description

- Fixed error messages in create group and edit group modal

### Video or Screenshots

#### Screenshots
<img width="573" alt="Screenshot 2022-09-28 at 1 39 04 PM" src="https://user-images.githubusercontent.com/109214920/192726030-d0ee1e93-fd69-4c8c-809d-59414662bdde.png">


### Other Details

- [SNHUT-1735](https://collectiveshift.atlassian.net/browse/SNHUT-1735)

#### Checklist

- [x] **All new necessary Unit tests were CREATED** to promote code coverage
- [x] **All required unit tests are PASSING**
- [x] The proposed functionality was tested manually locally, and it's working fine.
- [ ] PR was properly reviewed by a team member (at least 1 approval required to merge!)
