### PR TITLE
Added user confirmation when unsaved changes are available

### DIFF
--- a/apps/toboggan-app/src/app/group/components/permission/permission.component.ts
+++ b/apps/toboggan-app/src/app/group/components/permission/permission.component.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { Component, OnInit } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
+import { Observable } from 'rxjs';
+import { IComponentCanDeactivate } from '../../services/pending-changes.guard';
 import { permissionRadio } from './data/permissions';
 
 @Component({
@@ -9,10 +11,15 @@ import { permissionRadio } from './data/permissions';
   templateUrl: './permission.component.html',
   styleUrls: ['./permission.component.scss'],
 })
-export class PermissionComponent implements OnInit {
+export class PermissionComponent implements OnInit, IComponentCanDeactivate {
   groupPermissionForm!: FormGroup;
   permissions!: any[];
-  constructor() { }
+  constructor() {}
+
+  @HostListener('window:beforeunload')
+  canDeactivate(): Observable<boolean> | boolean {
+    return this.groupPermissionForm.pristine;
+  }
 
   ngOnInit(): void {
     this.permissions = permissionRadio;
@@ -23,10 +30,9 @@ export class PermissionComponent implements OnInit {
     });
   }
 
-  onCheckboxToggle(e: any) {
-  }
+  onCheckboxToggle(e: any) {}
 
   onSubmit() {
-    console.log(this.groupPermissionForm)
+    console.log(this.groupPermissionForm);
   }
 }

--- a/apps/toboggan-app/src/app/group/group.routing.ts
+++ b/apps/toboggan-app/src/app/group/group.routing.ts
@@ -1,9 +1,15 @@
 import { RouterModule, Routes } from '@angular/router';
 import { GroupDetailsPageComponent } from './pages/group-details-page/group-details-page.component';
 import { GroupMainPageComponent } from './pages/group-main-page/group-main-page.component';
+import { PendingChangesGuard } from './services/pending-changes.guard';
 
 const groupRoutes: Routes = [
-    { path: '', component: GroupMainPageComponent },
-    { path: 'details/:id', component: GroupDetailsPageComponent }];
+  { path: '', component: GroupMainPageComponent },
+  {
+    path: 'details/:id',
+    component: GroupDetailsPageComponent,
+    canDeactivate: [PendingChangesGuard],
+  },
+];
 
 export const groupRouting = RouterModule.forChild(groupRoutes);

--- a/apps/toboggan-app/src/app/group/pages/group-details-page/group-details-page.component.html
+++ b/apps/toboggan-app/src/app/group/pages/group-details-page/group-details-page.component.html
@@ -2,17 +2,27 @@
   <div class="p-5">
     <toboggan-ws-banner></toboggan-ws-banner>
     <toboggan-ws-modal-alert></toboggan-ws-modal-alert>
-    <a gp-link iconId="gp-icon-west" iconVariations="iconleft">Back to User Groups</a>
+    <a
+      gp-link
+      iconId="gp-icon-west"
+      iconVariations="iconleft"
+      routerLink="/group"
+      >Back to User Groups</a
+    >
     <div class="gp-level-4 mt-6">User Group</div>
     <div *ngIf="group">
       <div class="gp-level-5">{{ group.name }}</div>
       <div class="my-6">{{ group.description }}</div>
     </div>
-    <gp-tabs>
+    <gp-tabs (click)="onTabChange($event)">
       <gp-tab label="Users">
         <toboggan-ws-list-users [group]="group">
           <div table-cta-right>
-            <button gp-button class="add-user-group-btn" (click)="openAddUserToGroupModal()">
+            <button
+              gp-button
+              class="add-user-group-btn"
+              (click)="openAddUserToGroupModal()"
+            >
               Add user
             </button>
           </div>
@@ -22,22 +32,41 @@
         <div class="row pb-5 pb-md-8 g-5 g-md-8">
           <div class="col-3">
             <div class="p-4">
-              <button gp-button iconVariations="iconleft" label="Edit app access" size="default" styleType="secondary"
-                iconId="gp-icon-settings" [isLoading]="false"></button>
+              <button
+                gp-button
+                iconVariations="iconleft"
+                label="Edit app access"
+                size="default"
+                styleType="secondary"
+                iconId="gp-icon-settings"
+                [isLoading]="false"
+              ></button>
               <div class="slide-left">
                 <div class="gp-level-6 mb-4">Applications</div>
-                <button *ngFor="let tab of leftTabs" gp-button [label]="tab.label" size="default"
-                  [styleType]="tab.active?'secondary':'tertiary'" (click)="changeTab(tab)"></button>
+                <button
+                  *ngFor="let tab of leftTabs"
+                  gp-button
+                  [label]="tab.label"
+                  size="default"
+                  [styleType]="tab.active ? 'secondary' : 'tertiary'"
+                  (click)="changeTab(tab)"
+                ></button>
               </div>
             </div>
           </div>
           <div class="col-9">
-            <toboggan-ws-permission *ngIf="activeLeftTab === 0"></toboggan-ws-permission>
+            <toboggan-ws-permission
+              *ngIf="activeLeftTab === 0"
+            ></toboggan-ws-permission>
           </div>
         </div>
       </gp-tab>
     </gp-tabs>
   </div>
-  <toboggan-ws-add-users *ngIf="showAddUserModal" (addUserToGroupAction)="handleAddUserToGroupAction()" [group]="group">
+  <toboggan-ws-add-users
+    *ngIf="showAddUserModal"
+    (addUserToGroupAction)="handleAddUserToGroupAction()"
+    [group]="group"
+  >
   </toboggan-ws-add-users>
 </gp-page>

--- a/apps/toboggan-app/src/app/group/pages/group-details-page/group-details-page.component.spec.ts
+++ b/apps/toboggan-app/src/app/group/pages/group-details-page/group-details-page.component.spec.ts
@@ -32,7 +32,7 @@ describe('GroupDetailsPageComponent', () => {
         GroupDetailsPageComponent,
         ListUsersComponent,
         AddUsersComponent,
-        PermissionComponent
+        PermissionComponent,
       ],
     }).compileComponents();
 
@@ -52,5 +52,51 @@ describe('GroupDetailsPageComponent', () => {
     addUserBtn.click();
     fixture.detectChanges();
     expect(component.showAddUserModal).toBeTruthy();
+  });
+
+  it('should open user confirmation', () => {
+    const usersTabButton = fixture.debugElement
+      .queryAll(By.css('button'))
+      .find(
+        (buttonDebugEl) =>
+          buttonDebugEl.nativeElement.textContent.trim() === 'Users'
+      );
+
+    const permissionTabButton = fixture.debugElement
+      .queryAll(By.css('button'))
+      .find(
+        (buttonDebugEl) =>
+          buttonDebugEl.nativeElement.textContent.trim() === 'Permissions'
+      );
+
+    permissionTabButton?.nativeElement.click();
+    fixture.detectChanges();
+
+    component.permissionComponent.groupPermissionForm.markAsDirty();
+    fixture.detectChanges();
+
+    usersTabButton?.nativeElement.click();
+
+    fixture.detectChanges();
+
+    const backToGroupLink = fixture.debugElement
+      .queryAll(By.css('a'))
+      .find(
+        (buttonDebugEl) =>
+          buttonDebugEl.nativeElement.textContent.trim() ===
+          'Back to User Groups'
+      );
+    const onTabChangeSpy = jest.spyOn(component, 'onTabChange');
+    const userConfirmationSpy = jest.spyOn(
+      component,
+      'openUserConfirmationModal'
+    );
+    backToGroupLink?.nativeElement.click();
+    fixture.detectChanges();
+
+    fixture.whenStable().then(() => {
+      expect(onTabChangeSpy).toHaveBeenCalled();
+      expect(userConfirmationSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/apps/toboggan-app/src/app/group/pages/group-details-page/group-details-page.component.ts
+++ b/apps/toboggan-app/src/app/group/pages/group-details-page/group-details-page.component.ts
@@ -1,29 +1,49 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { TabsComponent } from '@snhuproduct/toboggan-ui-components-library';
 import { IGroup } from '@toboggan-ws/toboggan-common';
+import { Observable } from 'rxjs';
+import { ModalAlertService } from '../../../shared/services/modal-alert/modal-alert.service';
+import { PermissionComponent } from '../../components/permission/permission.component';
 import { GroupService } from '../../services/group.service';
+import { IComponentCanDeactivate } from '../../services/pending-changes.guard';
 import { applicationTab } from './data/applicationTab';
 @Component({
   selector: 'toboggan-ws-group-details-page',
   templateUrl: './group-details-page.component.html',
   styleUrls: ['./group-details-page.component.scss'],
 })
-export class GroupDetailsPageComponent implements OnInit {
+export class GroupDetailsPageComponent
+  implements OnInit, IComponentCanDeactivate
+{
   id: any;
   group!: IGroup;
   showAddUserModal = false;
   leftTabs = applicationTab;
   activeLeftTab = 0;
+
+  @ViewChild(TabsComponent) tabsComponent: TabsComponent = {} as TabsComponent;
+  @ViewChild(PermissionComponent) permissionComponent: PermissionComponent =
+    {} as PermissionComponent;
   constructor(
     private route: ActivatedRoute,
-    private groupService: GroupService
-  ) { }
+    private groupService: GroupService,
+    private modalAlertService: ModalAlertService
+  ) {}
 
   ngOnInit(): void {
     this.id = this.route.snapshot.paramMap.get('id');
     this.getGroupDetails();
+  }
+
+  canDeactivate(): Observable<boolean> | boolean {
+    if (this.tabsComponent.activeTabIndex == 1) {
+      return this.permissionComponent.canDeactivate();
+    } else {
+      return true;
+    }
   }
 
   getGroupDetails(): void {
@@ -42,12 +62,49 @@ export class GroupDetailsPageComponent implements OnInit {
 
   changeTab(tab: any) {
     this.activeLeftTab = tab.id;
-    this.leftTabs.forEach(data => {
+    this.leftTabs.forEach((data) => {
       if (data.id === tab.id) {
         data.active = true;
       } else {
         data.active = false;
       }
-    })
+    });
+  }
+
+  onTabChange(event: any) {
+    if (
+      event.target.innerText == 'Users' &&
+      !this.permissionComponent.canDeactivate()
+    ) {
+      console.log('unsaved data is there');
+      this.openUserConfirmationModal();
+    }
+  }
+
+  openUserConfirmationModal() {
+    this.modalAlertService.showModalAlert({
+      type: 'warning',
+      heading: `Leave this page?`,
+      message: `If you leave, your changes won’t be saved. `,
+      buttons: [
+        {
+          title: 'No, continue editing',
+          onClick: () => {
+            console.log('no');
+            this.modalAlertService.hideModalAlert();
+            this.tabsComponent.showTab(1);
+          },
+          style: 'secondary',
+        },
+        {
+          title: 'Yes, leave page',
+          onClick: () => {
+            this.modalAlertService.hideModalAlert();
+            console.log('yes ');
+          },
+          style: 'primary',
+        },
+      ],
+    });
   }
 }

--- a/apps/toboggan-app/src/app/group/services/pending-changes.guard.ts
+++ b/apps/toboggan-app/src/app/group/services/pending-changes.guard.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@angular/core';
+import { CanDeactivate } from '@angular/router';
+import { Observable, Subject } from 'rxjs';
+import { ModalAlertService } from '../../shared/services/modal-alert/modal-alert.service';
+
+export interface IComponentCanDeactivate {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  canDeactivate: (event?: any) => boolean | Observable<boolean>;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PendingChangesGuard
+  implements CanDeactivate<IComponentCanDeactivate>
+{
+  canLeave$ = new Subject<boolean>();
+
+  constructor(private modalAlertService: ModalAlertService) {}
+
+  canDeactivate(
+    component: IComponentCanDeactivate
+  ): boolean | Observable<boolean> {
+    if (!component.canDeactivate()) {
+      this.confirmUserAction();
+    }
+    return component.canDeactivate() ? true : this.canLeave$;
+  }
+
+  confirmUserAction() {
+    this.modalAlertService.showModalAlert({
+      type: 'warning',
+      heading: `Leave this page?`,
+      message: `If you leave, your changes won’t be saved. `,
+      buttons: [
+        {
+          title: 'No, continue editing',
+          onClick: () => {
+            console.log('no');
+            this.modalAlertService.hideModalAlert();
+            this.canLeave$.next(false);
+          },
+          style: 'secondary',
+        },
+        {
+          title: 'Yes, leave page',
+          onClick: () => {
+            this.modalAlertService.hideModalAlert();
+            this.canLeave$.next(true);
+            console.log('yes ');
+          },
+          style: 'primary',
+        },
+      ],
+    });
+  }
+}


### PR DESCRIPTION
### Description

- Added user confirmation box and modal whenever user trying to move from group permissions page and an unsaved change is exists

### Video or Screenshots

#### Screenshots

<img width="648" alt="Screenshot 2022-10-11 at 4 32 31 PM" src="https://user-images.githubusercontent.com/109214920/195073765-6f2f0977-701d-405b-a680-d213fc452ea0.png">
<img width="324" alt="Screenshot 2022-10-11 at 4 32 59 PM" src="https://user-images.githubusercontent.com/109214920/195073778-7cd3786e-7503-46a2-a74d-0e70c8554c34.png">

### Other Details

- [SNHUT-595](https://collectiveshift.atlassian.net/browse/SNHUT-595)

#### Checklist

- [x] **Assumptions of User Story met (including acceptance criteria)**
- [x] **All new necessary Unit tests were CREATED** to promote code coverage
- [x] **All required unit tests are PASSING**
- [x] The proposed functionality was tested manually locally, and it's working fine.
- [x] PR was properly reviewed by a team member (at least 1 approval required to merge!)
- [x] Unnecessary console.logs AND/OR comments were removed
