### PR TITLE
SNHUT-2134 - fixed initial sorting for application  and module

### DIFF
--- a/apps/toboggan-api/src/providers/permissions/permissions.mock.ts
+++ b/apps/toboggan-api/src/providers/permissions/permissions.mock.ts
@@ -43,14 +43,23 @@ for (let i = 0, j = 0, k = 0, m = 0; i < 20; i++) {
       description: '',
     },
   ];
-
-  permissions.push({
-    id: `id-${i}`,
-    application: 'Application Admin',
-    module: modules[k],
-    accessLevel: accessLevels[j],
-    userGroups: groups,
-  });
+  if (i < 5) {
+    permissions.push({
+      id: `id-${i}`,
+      application: 'A1',
+      module: modules[k],
+      accessLevel: accessLevels[j],
+      userGroups: groups,
+    });
+  } else {
+    permissions.push({
+      id: `id-${i}`,
+      application: 'BApplication Admin',
+      module: modules[k],
+      accessLevel: accessLevels[j],
+      userGroups: groups,
+    });
+  }
 
   j++;
   k++;

--- a/apps/toboggan-app/src/app/permission/components/permissions-list/permissions-list.component.ts
+++ b/apps/toboggan-app/src/app/permission/components/permissions-list/permissions-list.component.ts
@@ -126,7 +126,9 @@ export class PermissionsListComponent implements OnInit, OnDestroy {
     const permissions = fetchedData as IPermission[];
     // TODO: Ideally it should come sorted from our API!
     let userGroupList: IGroup[] = [];
-    const data = permissions.map((permission, index) => {
+    // initial sorting
+    const permissionsList = this.sortPermissions(permissions);
+    const data = permissionsList.map((permission, index) => {
       userGroupList = R.concat(userGroupList, permission.userGroups);
       const groupLinkList = permission.userGroups.map((group) => {
         return {
@@ -237,5 +239,17 @@ export class PermissionsListComponent implements OnInit, OnDestroy {
       additionalFilterFuncs.push(this.filterFuncs[key]);
     });
     this.refreshTableData(additionalFilterFuncs);
+  }
+
+  private sortPermissions(permissions: IPermission[]) {
+    return permissions
+      .sort((a, b) =>
+        a.application > b.application
+          ? 1
+          : b.application > a.application
+          ? -1
+          : 0
+      )
+      .sort((a, b) => (a.module > b.module ? 1 : b.module > a.module ? -1 : 0));
   }
 }


### PR DESCRIPTION
### Description

-Permissions list table is now initially have 2 sorts - alphabetical by application and then alphabetical by module

### Video or Screenshots

#### Screenshots

<img width="1311" alt="Screenshot 2022-10-19 at 2 19 32 PM" src="https://user-images.githubusercontent.com/109214920/196644232-37ce06c9-5af7-4dcd-9ba4-3ac414ac2d04.png">

### Other Details

- [JIRA Ticket](https://collectiveshift.atlassian.net/browse/SNHUT-2134)

#### Checklist

- [x] **Assumptions of User Story met (including acceptance criteria)**
- [x] **All new necessary Unit tests were CREATED** to promote code coverage
- [x] **All required unit tests are PASSING**
- [x] The proposed functionality was tested manually locally, and it's working fine.
- [ ] PR was properly reviewed by a team member (at least 1 approval required to merge!)
- [x] Unnecessary console.logs AND/OR comments were removed
