### PR TITLE
pagination added for nestjs api - groups, users and permissions

### DIFF
--- a/apps/toboggan-api/src/app/modules/groups/groups.controller.spec.ts
+++ b/apps/toboggan-api/src/app/modules/groups/groups.controller.spec.ts
@@ -68,14 +68,11 @@ describe('GroupsController', () => {
 
       controller
         .getGroups({
-          currentPage: 1,
-          resultsPerPage: 10,
+          skip: 1,
+          limit: 10,
         })
         .subscribe((response) => {
-          expect(service.getGroups).toHaveBeenCalledWith({
-            limit: 10,
-            skip: 1,
-          });
+          expect(service.getGroups).toHaveBeenCalledWith(1, 10);
           expect(response).toBe(mockResponse);
         });
     });

--- a/apps/toboggan-api/src/app/modules/groups/groups.controller.ts
+++ b/apps/toboggan-api/src/app/modules/groups/groups.controller.ts
@@ -31,9 +31,8 @@ export class GroupsController {
 
   @Get('/')
   getGroups(@Query() query) {
-    const { currentPage: skip, resultsPerPage: limit } = query;
-
-    return this.groupsService.getGroups({ skip, limit });
+    const { skip, limit } = query;
+    return this.groupsService.getGroups(skip, limit);
   }
 
   @Get('/:uuid')

--- a/apps/toboggan-api/src/app/modules/groups/groups.service.spec.ts
+++ b/apps/toboggan-api/src/app/modules/groups/groups.service.spec.ts
@@ -1,18 +1,67 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { HttpModule, HttpService } from '@nestjs/axios';
 import { Test, TestingModule } from '@nestjs/testing';
+import { of } from 'rxjs';
+import { environment } from '../../../environments/environment';
 import { GroupsService } from './groups.service';
 
 describe('GroupsService', () => {
+  let module: TestingModule;
   let service: GroupsService;
+  let http: HttpService;
+  const data = {
+    data: {},
+  };
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        HttpModule.register({
+          baseURL: environment.GPCoreBaseUrl + '/authentication/api/v1',
+          timeout: 8000,
+          maxRedirects: 3,
+        }),
+      ],
       providers: [GroupsService],
     }).compile();
+  });
 
+  beforeEach(async () => {
     service = module.get<GroupsService>(GroupsService);
+    http = module.get<HttpService>(HttpService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('checkPagination', () => {
+    it('should work with given pagination', (done) => {
+      // @ts-ignore
+      jest.spyOn(http, 'get').mockImplementation(() => of(data));
+      expect(
+        service.getGroups(1, 10).subscribe((response) => {
+          expect(http.get).toBeCalledWith('/groups', {
+            params: { limit: 10, skip: 1 },
+          });
+          expect(response).toEqual(data);
+          done();
+        })
+      );
+    });
+
+    it('should work with default pagination', (done) => {
+      // @ts-ignore
+      jest.spyOn(http, 'get').mockImplementation(() => of(data));
+      expect(
+        service.getGroups(undefined, undefined).subscribe((response) => {
+          expect(http.get).toBeCalledWith('/groups', {
+            params: { limit: 1000, skip: 0 },
+          });
+          expect(response).toEqual(data);
+          done();
+        })
+      );
+    });
   });
 });

--- a/apps/toboggan-api/src/app/modules/groups/groups.service.ts
+++ b/apps/toboggan-api/src/app/modules/groups/groups.service.ts
@@ -34,10 +34,11 @@ export class GroupsService {
   //   return this.groups;
   // }
 
-  getGroups(params?: {
-    skip?: number;
-    limit?: number;
-  }): Observable<AxiosResponse<IGroup[]>> {
+  getGroups(skip: number, limit: number): Observable<AxiosResponse<IGroup[]>> {
+    const params = {
+      skip: skip ?? 0,
+      limit: limit ?? 1000,
+    };
     return this.httpService.get('/groups', { params });
   }
 

--- a/apps/toboggan-api/src/app/modules/permissions/permission.controller.spec.ts
+++ b/apps/toboggan-api/src/app/modules/permissions/permission.controller.spec.ts
@@ -1,12 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { HttpModule } from '@nestjs/axios';
+import { AxiosResponse } from 'axios';
+import { of } from 'rxjs';
+import { environment } from '../../../environments/environment';
 import { PermissionsController } from './permissions.controller';
 import { mockPermissions } from './permissions.mock';
 import { PermissionService } from './permissions.service';
-import { AxiosResponse } from 'axios';
-import { HttpModule } from '@nestjs/axios';
-import { environment } from '../../../environments/environment';
-import { of } from 'rxjs';
 
 const mockResponse: AxiosResponse = {
   data: null,
@@ -49,14 +49,11 @@ describe('PermissionsController', () => {
 
       controller
         .getPermissions({
-          currentPage: 1,
-          resultsPerPage: 10,
+          skip: 1,
+          limit: 10,
         })
         .subscribe((response) => {
-          expect(service.getPermissions).toHaveBeenCalledWith({
-            limit: 10,
-            skip: 1,
-          });
+          expect(service.getPermissions).toHaveBeenCalledWith(1, 10);
           expect(response).toBe(mockResponse);
         });
     });

--- a/apps/toboggan-api/src/app/modules/permissions/permissions.controller.ts
+++ b/apps/toboggan-api/src/app/modules/permissions/permissions.controller.ts
@@ -24,9 +24,9 @@ export class PermissionsController {
 
   @Get('/')
   getPermissions(@Query() query) {
-    const { currentPage: skip, resultsPerPage: limit } = query;
+    const { skip, limit } = query;
 
-    return this.permissionService.getPermissions({ skip, limit });
+    return this.permissionService.getPermissions(skip, limit);
   }
 
   @Get('/:id')

--- a/apps/toboggan-api/src/app/modules/permissions/permissions.service.spec.ts
+++ b/apps/toboggan-api/src/app/modules/permissions/permissions.service.spec.ts
@@ -1,18 +1,67 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { HttpModule, HttpService } from '@nestjs/axios';
 import { Test, TestingModule } from '@nestjs/testing';
+import { of } from 'rxjs';
+import { environment } from '../../../environments/environment';
 import { PermissionService } from './permissions.service';
 
-describe('PermissionService', () => {
+describe('GroupsService', () => {
+  let module: TestingModule;
   let service: PermissionService;
+  let http: HttpService;
+  const data = {
+    data: {},
+  };
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        HttpModule.register({
+          baseURL: environment.GPCoreBaseUrl + '/authentication/api/v1',
+          timeout: 8000,
+          maxRedirects: 3,
+        }),
+      ],
       providers: [PermissionService],
     }).compile();
+  });
 
+  beforeEach(async () => {
     service = module.get<PermissionService>(PermissionService);
+    http = module.get<HttpService>(HttpService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('checkPagination', () => {
+    it('should work with given pagination', (done) => {
+      // @ts-ignore
+      jest.spyOn(http, 'get').mockImplementation(() => of(data));
+      expect(
+        service.getPermissions(1, 10).subscribe((response) => {
+          expect(http.get).toBeCalledWith('/permissions', {
+            params: { limit: 10, skip: 1 },
+          });
+          expect(response).toEqual(data);
+          done();
+        })
+      );
+    });
+
+    it('should work with default pagination', (done) => {
+      // @ts-ignore
+      jest.spyOn(http, 'get').mockImplementation(() => of(data));
+      expect(
+        service.getPermissions(undefined, undefined).subscribe((response) => {
+          expect(http.get).toBeCalledWith('/permissions', {
+            params: { limit: 1000, skip: 0 },
+          });
+          expect(response).toEqual(data);
+          done();
+        })
+      );
+    });
   });
 });

--- a/apps/toboggan-api/src/app/modules/permissions/permissions.service.ts
+++ b/apps/toboggan-api/src/app/modules/permissions/permissions.service.ts
@@ -24,10 +24,14 @@ export class PermissionService {
   //   return this.permissions;
   // }
 
-  getPermissions(params?: {
-    skip?: number;
-    limit?: number;
-  }): Observable<AxiosResponse<IPermission[]>> {
+  getPermissions(
+    skip: number,
+    limit: number
+  ): Observable<AxiosResponse<IPermission[]>> {
+    const params = {
+      skip: skip ?? 0,
+      limit: limit ?? 1000,
+    };
     return this.httpService.get('/permissions', { params });
   }
 

--- a/apps/toboggan-api/src/app/modules/users/users.controller.spec.ts
+++ b/apps/toboggan-api/src/app/modules/users/users.controller.spec.ts
@@ -2,6 +2,7 @@
 import { HttpModule } from '@nestjs/axios';
 import { Test, TestingModule } from '@nestjs/testing';
 import { IUser } from '@toboggan-ws/toboggan-common';
+import { of } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { UsersController } from './users.controller';
 import { CreateUserDTO } from './users.dto';
@@ -57,11 +58,28 @@ describe('UsersController', () => {
   });
 
   describe('getUsers', () => {
-    it('should return an array of users', async () => {
+    it('should return an array of users with email query', async () => {
       //@ts-ignore
-      jest.spyOn(service, 'getUsers').mockImplementation(() => users);
+      jest.spyOn(service, 'searchUser').mockImplementation(() => of(users));
 
-      expect(await controller.getUsers({})).toBe(users);
+      controller
+        .getUsers({ skip: 1, limit: 10, user_type: 'type', email: 'email' })
+        .subscribe((response) => {
+          expect(service.searchUser).toHaveBeenCalledWith('email');
+          expect(response).toBe(users);
+        });
+    });
+
+    it('should return an array of users without email query', async () => {
+      //@ts-ignore
+      jest.spyOn(service, 'getUsers').mockImplementation(() => of(users));
+
+      controller
+        .getUsers({ skip: 1, limit: 10, user_type: 'type' })
+        .subscribe((response) => {
+          expect(service.getUsers).toHaveBeenCalledWith(1, 10, 'type');
+          expect(response).toBe(users);
+        });
     });
   });
 

--- a/apps/toboggan-api/src/app/modules/users/users.service.spec.ts
+++ b/apps/toboggan-api/src/app/modules/users/users.service.spec.ts
@@ -1,18 +1,67 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { HttpModule, HttpService } from '@nestjs/axios';
 import { Test, TestingModule } from '@nestjs/testing';
+import { of } from 'rxjs';
+import { environment } from '../../../environments/environment';
 import { UsersService } from './users.service';
 
-describe('UsersService', () => {
+describe('GroupsService', () => {
+  let module: TestingModule;
   let service: UsersService;
+  let http: HttpService;
+  const data = {
+    data: {},
+  };
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        HttpModule.register({
+          baseURL: environment.GPCoreBaseUrl + '/authentication/api/v1',
+          timeout: 8000,
+          maxRedirects: 3,
+        }),
+      ],
       providers: [UsersService],
     }).compile();
+  });
 
+  beforeEach(async () => {
     service = module.get<UsersService>(UsersService);
+    http = module.get<HttpService>(HttpService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('checkPagination', () => {
+    it('should work with given pagination', (done) => {
+      // @ts-ignore
+      jest.spyOn(http, 'get').mockImplementation(() => of(data));
+      expect(
+        service.getUsers(1, 10).subscribe((response) => {
+          expect(http.get).toBeCalledWith('/users', {
+            params: { limit: 10, skip: 1, userType: null },
+          });
+          expect(response).toEqual(data);
+          done();
+        })
+      );
+    });
+
+    it('should work with default pagination', (done) => {
+      // @ts-ignore
+      jest.spyOn(http, 'get').mockImplementation(() => of(data));
+      expect(
+        service.getUsers(undefined, undefined).subscribe((response) => {
+          expect(http.get).toBeCalledWith('/users', {
+            params: { limit: 1000, skip: 0, userType: null },
+          });
+          expect(response).toEqual(data);
+          done();
+        })
+      );
+    });
   });
 });

--- a/apps/toboggan-api/src/app/modules/users/users.service.ts
+++ b/apps/toboggan-api/src/app/modules/users/users.service.ts
@@ -11,13 +11,12 @@ export class UsersService {
   constructor(private readonly httpService: HttpService) {}
 
   getUsers(skip: number, limit: number, userType?: UserType) {
-    return this.httpService.get('/users', {
-      params: {
-        skip,
-        limit,
-        user_type: userType,
-      },
-    });
+    const params = {
+      skip: skip ?? 0,
+      limit: limit ?? 1000,
+      userType: userType ?? null,
+    };
+    return this.httpService.get('/users', { params });
   }
 
   getUser(id: string) {


### PR DESCRIPTION
### Description

- Currently, we have integrated fetch services for groups, users, and permissions. In controllers, we are passing skip as well as limit to fetch data. As per current understanding we’ll be handling pagination in client side. So we need to update skip and limit parameter in service in such a way , that, it is picking up at least 500-1000 records

#### Screenshots
<img width="592" alt="Screenshot 2022-11-30 at 5 51 45 PM" src="https://user-images.githubusercontent.com/116863369/204795330-00f40e4e-e246-4a7c-81ca-2b6708b76bb1.png">


### Other Details

- [JIRA Ticket](https://collectiveshift.atlassian.net/browse/SNHUT-2719)

#### Checklist

- [ ] **Assumptions of User Story met (including acceptance criteria)**
- [ ] **All new necessary Unit tests were CREATED** to promote code coverage
- [ ] **All required unit tests are PASSING**
- [ ] The proposed functionality was tested manually locally, and it's working fine.
- [ ] PR was properly reviewed by a team member (at least 1 approval required to merge!)
- [ ] Unnecessary console.logs AND/OR comments were removed
- [ ] Feature ok-ed by UX designer (If needed - not for back end components) and Product Owner
- [ ] Ensure configuration and/or build changes documented
